### PR TITLE
bump gormVersion to 6.1.7.BUILD-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-gormVersion=6.1.6.BUILD-SNAPSHOT
+gormVersion=6.1.7.BUILD-SNAPSHOT
 grailsVersion=3.2.10
 grails2Version=2.5.6
 groovyVersion=2.4.11


### PR DESCRIPTION
This is related to https://github.com/grails/gorm-hibernate4/pull/7.
The gormVersion needs to be bumped since https://github.com/grails/grails-data-mapping/pull/977 was just merged and grails-data-mapping master is now 6.1.7.BUILD-SNAPSHOT.
